### PR TITLE
Pull images from our registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /k8s-rds
+.idea*

--- a/local/local_provider.go
+++ b/local/local_provider.go
@@ -241,7 +241,7 @@ func toSpec(db *crd.Database) v1.DeploymentSpec {
 				Containers: []corev1.Container{
 					{
 						Name:  db.Name,
-						Image: fmt.Sprintf("%v:%v", db.Spec.Engine, version), // TODO is this correct
+						Image: fmt.Sprintf("eu.gcr.io/tradeshift-base/%v:%v", db.Spec.Engine, version), // TODO is this correct
 						Env: []corev1.EnvVar{corev1.EnvVar{
 							Name: "POSTGRES_PASSWORD",
 							ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
This commit makes the local provider pull images from our own registry,
to get around dockerhub rate limit and public images being removed.