### PR TITLE
POPS-2212 Make k8s-rds docker image run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,7 @@ RUN apk --no-cache add ca-certificates
 
 COPY --from=builder /app/bin/k8s-rds /k8s-rds
 
+RUN chown tradeshift /k8s-rds
+USER tradeshift
+
 ENTRYPOINT ["/k8s-rds"]


### PR DESCRIPTION
This commit will change the docker image to not run as root. It will
be ran as user 'tradeshift'.