### PR TITLE
POPS-2560 Upgrade Database CRD API version to v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /k8s-rds
+/bin
 *.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ type: Opaque
 data:
   mykey: cGFzc3dvcmRvcnNvbWV0aGluZw==
 ---
-apiVersion: k8s.io/v1
+apiVersion: tradeshift.com/v1
 kind: Database
 metadata:
   name: pgsql

--- a/crd/crd.go
+++ b/crd/crd.go
@@ -2,8 +2,9 @@ package crd
 
 import (
 	"context"
+
 	v1 "k8s.io/api/core/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,10 +16,11 @@ import (
 
 const (
 	CRDPlural          string = "databases"
-	CRDGroup           string = "k8s.io"
+	CRDGroup           string = "tradeshift.com"
 	CRDVersion         string = "v1"
 	FullCRDName        string = "databases." + CRDGroup
-	StorageTypePattern string = `gp2|io1`
+	ProviderPattern    string = `local|aws`
+	StorageTypePattern string = `gp2|gp3|io1`
 	DBNamePattern      string = "^[A-Za-z]\\w+$"
 	DBUsernamePattern  string = "^[A-Za-z]\\w+$"
 )
@@ -31,98 +33,127 @@ func floatptr(x float64) *float64 {
 	return &x
 }
 
-func NewDatabaseCRD() *apiextv1beta1.CustomResourceDefinition {
-	return &apiextv1beta1.CustomResourceDefinition{
+func NewDatabaseCRD() *apiextv1.CustomResourceDefinition {
+	return &apiextv1.CustomResourceDefinition{
 		ObjectMeta: meta_v1.ObjectMeta{Name: FullCRDName},
-		Spec: apiextv1beta1.CustomResourceDefinitionSpec{
-			Group:   CRDGroup,
-			Version: CRDVersion,
-			Scope:   apiextv1beta1.NamespaceScoped,
-			Names: apiextv1beta1.CustomResourceDefinitionNames{
-				Plural: "databases",
+		Spec: apiextv1.CustomResourceDefinitionSpec{
+			Group: CRDGroup,
+			Names: apiextv1.CustomResourceDefinitionNames{
+				Plural: CRDPlural,
 				Kind:   "Database",
 			},
-			Validation: &apiextv1beta1.CustomResourceValidation{
-				OpenAPIV3Schema: &apiextv1beta1.JSONSchemaProps{
-					Type: "object",
-					Properties: map[string]apiextv1beta1.JSONSchemaProps{
-						"spec": {
+			Scope: apiextv1.NamespaceScoped,
+			Conversion: &apiextv1.CustomResourceConversion{
+				Strategy: "None",
+			},
+			Versions: []apiextv1.CustomResourceDefinitionVersion{
+				{
+					Name:    CRDVersion,
+					Served:  true,
+					Storage: true,
+					Schema: &apiextv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextv1.JSONSchemaProps{
 							Type: "object",
-							Properties: map[string]apiextv1beta1.JSONSchemaProps{
-								"username": {
-									Type:        "string",
-									Description: "User Name to access the database",
-									MinLength:   intptr(1),
-									MaxLength:   intptr(16),
-									Pattern:     DBUsernamePattern,
-								},
-								"dbname": {
-									Type:        "string",
-									Description: "Database name",
-									MinLength:   intptr(1),
-									MaxLength:   intptr(63),
-									Pattern:     DBNamePattern,
-								},
-								"engine": {
-									Type:        "string",
-									Description: "database engine. Ex: postgres, mysql, aurora-postgresql, etc",
-								},
-								"version": {
-									Type:        "string",
-									Description: "database engine version. ex 5.1.49",
-								},
-								"class": {
-									Type:        "string",
-									Description: "instance class name. Ex: db.m5.24xlarge or db.m3.medium",
-								},
-								"size": {
-									Type:        "integer",
-									Description: "Database size in Gb",
-									Minimum:     floatptr(20),
-									Maximum:     floatptr(64000),
-								},
-								"MaxAllocatedSize": {
-									Type:        "integer",
-									Description: "Database size in Gb",
-									Minimum:     floatptr(20),
-									Maximum:     floatptr(64000),
-								},
-								"multiaz": {
-									Type:        "boolean",
-									Description: "should it be available in multiple regions?",
-								},
-								"publiclyaccessible": {
-									Type:        "boolean",
-									Description: "is the database publicly accessible?",
-								},
-								"storageencrypted": {
-									Type:        "boolean",
-									Description: "should the storage be encrypted?",
-								},
-								"storagetype": {
-									Type:        "string",
-									Description: "gp2 (General Purpose SSD) or io1 (Provisioned IOPS SSD)",
-									Pattern:     StorageTypePattern,
-								},
-								"iops": {
-									Type:        "integer",
-									Description: "I/O operations per second",
-									Minimum:     floatptr(1000),
-									Maximum:     floatptr(80000),
-								},
-								"backupretentionperiod": {
-									Type:        "integer",
-									Description: "Retention period in days. 0 means disabled, 7 is the default and 35 is the maximum",
-									Minimum:     floatptr(0),
-									Maximum:     floatptr(35),
-								},
-								"deleteprotection": {
-									Type:        "boolean",
-									Description: "Enable or disable deletion protection",
-								},
-								"tags": {
-									Type:        "string",
-									Description: "Tags to create on the database instance format key=value,key1=value1",
+							Properties: map[string]apiextv1.JSONSchemaProps{
+								"spec": {
+									Type: "object",
+									Properties: map[string]apiextv1.JSONSchemaProps{
+										"provider": {
+											Type:        "string",
+											Description: "The provider name for this cluster. Must be local or aws.",
+											Pattern:     ProviderPattern,
+										},
+										"username": {
+											Type:        "string",
+											Description: "User Name to access the database",
+											MinLength:   intptr(1),
+											MaxLength:   intptr(16),
+											Pattern:     DBUsernamePattern,
+										},
+										"password": {
+											Type:        "object",
+											Description: "The secret name and the key name used to retrive the password for this database.",
+											Required:    []string{"key", "name"},
+											Properties: map[string]apiextv1.JSONSchemaProps{
+												"key": {
+													Type:        "string",
+													Description: "The key name from the secret which contains the password used for this database.",
+												},
+												"name": {
+													Type:        "string",
+													Description: "The secret name which contains the password used for this database.",
+												},
+											},
+										},
+										"dbname": {
+											Type:        "string",
+											Description: "Database name",
+											MinLength:   intptr(1),
+											MaxLength:   intptr(63),
+											Pattern:     DBNamePattern,
+										},
+										"engine": {
+											Type:        "string",
+											Description: "database engine. Ex: postgres, mysql, aurora-postgresql, etc",
+										},
+										"version": {
+											Type:        "string",
+											Description: "database engine version. ex 5.1.49",
+										},
+										"class": {
+											Type:        "string",
+											Description: "instance class name. Ex: db.m5.24xlarge or db.m3.medium",
+										},
+										"size": {
+											Type:        "integer",
+											Description: "Database size in Gb",
+											Minimum:     floatptr(20),
+											Maximum:     floatptr(64000),
+										},
+										"MaxAllocatedSize": {
+											Type:        "integer",
+											Description: "Database size in Gb",
+											Minimum:     floatptr(20),
+											Maximum:     floatptr(64000),
+										},
+										"multiaz": {
+											Type:        "boolean",
+											Description: "should it be available in multiple regions?",
+										},
+										"publiclyaccessible": {
+											Type:        "boolean",
+											Description: "is the database publicly accessible?",
+										},
+										"encrypted": {
+											Type:        "boolean",
+											Description: "should the storage be encrypted?",
+										},
+										"storagetype": {
+											Type:        "string",
+											Description: "gp2 (General Purpose SSD), gp3 (Next generation of General Purpose SSD) or io1 (Provisioned IOPS SSD)",
+											Pattern:     StorageTypePattern,
+										},
+										"iops": {
+											Type:        "integer",
+											Description: "I/O operations per second",
+											Minimum:     floatptr(1000),
+											Maximum:     floatptr(80000),
+										},
+										"backupretentionperiod": {
+											Type:        "integer",
+											Description: "Retention period in days. 0 means disabled, 7 is the default and 35 is the maximum",
+											Minimum:     floatptr(0),
+											Maximum:     floatptr(35),
+										},
+										"deleteprotection": {
+											Type:        "boolean",
+											Description: "Enable or disable deletion protection",
+										},
+										"tags": {
+											Type:        "string",
+											Description: "Tags to create on the database instance format key=value,key1=value1",
+										},
+									},
 								},
 							},
 						},
@@ -137,7 +168,7 @@ func NewDatabaseCRD() *apiextv1beta1.CustomResourceDefinition {
 func CreateCRD(clientset apiextcs.Interface) error {
 	ctx := context.Background()
 	crd := NewDatabaseCRD()
-	_, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(ctx, crd, meta_v1.CreateOptions{})
+	_, err := clientset.ApiextensionsV1().CustomResourceDefinitions().Create(ctx, crd, meta_v1.CreateOptions{})
 	if err != nil && apierrors.IsAlreadyExists(err) {
 		return nil
 	}

--- a/crd/crd_test.go
+++ b/crd/crd_test.go
@@ -15,7 +15,7 @@ import (
 func TestMarshal(t *testing.T) {
 	d := Database{
 		ObjectMeta: meta_v1.ObjectMeta{Name: "my_db", Namespace: "default"},
-		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "k8s.io/v1"}, Spec: DatabaseSpec{BackupRetentionPeriod: 10,
+		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "tradeshift.com/v1"}, Spec: DatabaseSpec{BackupRetentionPeriod: 10,
 			Class:              "db.t2.micro",
 			DBName:             "database_name",
 			Engine:             "postgres",
@@ -40,7 +40,7 @@ func TestMarshal(t *testing.T) {
 func TestCRDValidationWithValidInput(t *testing.T) {
 	d := Database{
 		ObjectMeta: meta_v1.ObjectMeta{Name: "my_db", Namespace: "default"},
-		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "k8s.io/v1"},
+		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "tradeshift.com/v1"},
 		Spec: DatabaseSpec{
 			BackupRetentionPeriod: 10,
 			Class:                 "db.t2.micro",
@@ -58,7 +58,7 @@ func TestCRDValidationWithValidInput(t *testing.T) {
 		},
 	}
 
-	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Validation.OpenAPIV3Schema)
+	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Versions[0].Schema.OpenAPIV3Schema)
 	documentLoader := gojsonschema.NewGoLoader(d)
 
 	result, err := gojsonschema.Validate(loader, documentLoader)
@@ -71,10 +71,10 @@ func TestCaseInsensitiveInput(t *testing.T) {
 	yamlFile, err := ioutil.ReadFile("test.yaml")
 	assert.NoError(t, err)
 	db := Database{}
-	err = yaml.Unmarshal(yamlFile,&db)
+	err = yaml.Unmarshal(yamlFile, &db)
 	assert.NoError(t, err)
 	assert.Equal(t, int(db.Spec.MaxAllocatedSize), 200, "they should be equal")
-	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Validation.OpenAPIV3Schema)
+	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Versions[0].Schema.OpenAPIV3Schema)
 	documentLoader := gojsonschema.NewGoLoader(db)
 
 	result, err := gojsonschema.Validate(loader, documentLoader)
@@ -82,11 +82,10 @@ func TestCaseInsensitiveInput(t *testing.T) {
 	assert.True(t, result.Valid(), result.Errors())
 }
 
-
 func TestDatabaseSizeIsTooSmall(t *testing.T) {
 	d := Database{
 		ObjectMeta: meta_v1.ObjectMeta{Name: "my_db", Namespace: "default"},
-		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "k8s.io/v1"},
+		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "tradeshift.com/v1"},
 		Spec: DatabaseSpec{
 			BackupRetentionPeriod: 10,
 			Class:                 "db.t2.micro",
@@ -104,7 +103,7 @@ func TestDatabaseSizeIsTooSmall(t *testing.T) {
 		},
 	}
 
-	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Validation.OpenAPIV3Schema)
+	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Versions[0].Schema.OpenAPIV3Schema)
 	documentLoader := gojsonschema.NewGoLoader(d)
 
 	result, err := gojsonschema.Validate(loader, documentLoader)
@@ -115,7 +114,7 @@ func TestDatabaseSizeIsTooSmall(t *testing.T) {
 func TestDatabaseSizeIsTooBig(t *testing.T) {
 	d := Database{
 		ObjectMeta: meta_v1.ObjectMeta{Name: "my_db", Namespace: "default"},
-		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "k8s.io/v1"},
+		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "tradeshift.com/v1"},
 		Spec: DatabaseSpec{
 			BackupRetentionPeriod: 10,
 			Class:                 "db.t2.micro",
@@ -133,7 +132,7 @@ func TestDatabaseSizeIsTooBig(t *testing.T) {
 		},
 	}
 
-	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Validation.OpenAPIV3Schema)
+	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Versions[0].Schema.OpenAPIV3Schema)
 	documentLoader := gojsonschema.NewGoLoader(d)
 
 	result, err := gojsonschema.Validate(loader, documentLoader)
@@ -144,7 +143,7 @@ func TestDatabaseSizeIsTooBig(t *testing.T) {
 func TestBackupRetentionPeriodIsTooLong(t *testing.T) {
 	d := Database{
 		ObjectMeta: meta_v1.ObjectMeta{Name: "my_db", Namespace: "default"},
-		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "k8s.io/v1"},
+		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "tradeshift.com/v1"},
 		Spec: DatabaseSpec{
 			BackupRetentionPeriod: 36,
 			Class:                 "db.t2.micro",
@@ -162,7 +161,7 @@ func TestBackupRetentionPeriodIsTooLong(t *testing.T) {
 		},
 	}
 
-	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Validation.OpenAPIV3Schema)
+	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Versions[0].Schema.OpenAPIV3Schema)
 	documentLoader := gojsonschema.NewGoLoader(d)
 
 	result, err := gojsonschema.Validate(loader, documentLoader)
@@ -173,7 +172,7 @@ func TestBackupRetentionPeriodIsTooLong(t *testing.T) {
 func TestInvalidDatabaseNameWithDashSeparator(t *testing.T) {
 	d := Database{
 		ObjectMeta: meta_v1.ObjectMeta{Name: "my_db", Namespace: "default"},
-		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "k8s.io/v1"},
+		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "tradeshift.com/v1"},
 		Spec: DatabaseSpec{
 			BackupRetentionPeriod: 30,
 			Class:                 "db.t2.micro",
@@ -191,7 +190,7 @@ func TestInvalidDatabaseNameWithDashSeparator(t *testing.T) {
 		},
 	}
 
-	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Validation.OpenAPIV3Schema)
+	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Versions[0].Schema.OpenAPIV3Schema)
 	documentLoader := gojsonschema.NewGoLoader(d)
 
 	result, err := gojsonschema.Validate(loader, documentLoader)
@@ -202,7 +201,7 @@ func TestInvalidDatabaseNameWithDashSeparator(t *testing.T) {
 func TestInvalidDatabaseNameStartingWithANumber(t *testing.T) {
 	d := Database{
 		ObjectMeta: meta_v1.ObjectMeta{Name: "my_db", Namespace: "default"},
-		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "k8s.io/v1"},
+		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "tradeshift.com/v1"},
 		Spec: DatabaseSpec{
 			BackupRetentionPeriod: 30,
 			Class:                 "db.t2.micro",
@@ -220,7 +219,7 @@ func TestInvalidDatabaseNameStartingWithANumber(t *testing.T) {
 		},
 	}
 
-	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Validation.OpenAPIV3Schema)
+	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Versions[0].Schema.OpenAPIV3Schema)
 	documentLoader := gojsonschema.NewGoLoader(d)
 
 	result, err := gojsonschema.Validate(loader, documentLoader)
@@ -231,7 +230,7 @@ func TestInvalidDatabaseNameStartingWithANumber(t *testing.T) {
 func TestInvalidUsername(t *testing.T) {
 	d := Database{
 		ObjectMeta: meta_v1.ObjectMeta{Name: "my_db", Namespace: "default"},
-		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "k8s.io/v1"},
+		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "tradeshift.com/v1"},
 		Spec: DatabaseSpec{
 			BackupRetentionPeriod: 30,
 			Class:                 "db.t2.micro",
@@ -249,18 +248,19 @@ func TestInvalidUsername(t *testing.T) {
 		},
 	}
 
-	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Validation.OpenAPIV3Schema)
+	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Versions[0].Schema.OpenAPIV3Schema)
 	documentLoader := gojsonschema.NewGoLoader(d)
 
 	result, err := gojsonschema.Validate(loader, documentLoader)
 	assert.NoError(t, err)
 	assert.False(t, result.Valid(), result.Errors())
+
 }
 
 func TestInvalidStorageType(t *testing.T) {
 	d := Database{
 		ObjectMeta: meta_v1.ObjectMeta{Name: "my_db", Namespace: "default"},
-		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "k8s.io/v1"},
+		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "tradeshift.com/v1"},
 		Spec: DatabaseSpec{
 			BackupRetentionPeriod: 30,
 			Class:                 "db.t2.micro",
@@ -278,7 +278,7 @@ func TestInvalidStorageType(t *testing.T) {
 		},
 	}
 
-	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Validation.OpenAPIV3Schema)
+	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Versions[0].Schema.OpenAPIV3Schema)
 	documentLoader := gojsonschema.NewGoLoader(d)
 
 	result, err := gojsonschema.Validate(loader, documentLoader)
@@ -289,7 +289,7 @@ func TestInvalidStorageType(t *testing.T) {
 func TestIopsTooSmall(t *testing.T) {
 	d := Database{
 		ObjectMeta: meta_v1.ObjectMeta{Name: "my_db", Namespace: "default"},
-		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "k8s.io/v1"},
+		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "tradeshift.com/v1"},
 		Spec: DatabaseSpec{
 			BackupRetentionPeriod: 30,
 			Class:                 "db.t2.micro",
@@ -307,7 +307,7 @@ func TestIopsTooSmall(t *testing.T) {
 		},
 	}
 
-	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Validation.OpenAPIV3Schema)
+	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Versions[0].Schema.OpenAPIV3Schema)
 	documentLoader := gojsonschema.NewGoLoader(d)
 
 	result, err := gojsonschema.Validate(loader, documentLoader)
@@ -318,7 +318,7 @@ func TestIopsTooSmall(t *testing.T) {
 func TestIopsTooBig(t *testing.T) {
 	d := Database{
 		ObjectMeta: meta_v1.ObjectMeta{Name: "my_db", Namespace: "default"},
-		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "k8s.io/v1"},
+		TypeMeta:   meta_v1.TypeMeta{Kind: "Database", APIVersion: "tradeshift.com/v1"},
 		Spec: DatabaseSpec{
 			BackupRetentionPeriod: 30,
 			Class:                 "db.t2.micro",
@@ -336,7 +336,7 @@ func TestIopsTooBig(t *testing.T) {
 		},
 	}
 
-	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Validation.OpenAPIV3Schema)
+	loader := gojsonschema.NewGoLoader(NewDatabaseCRD().Spec.Versions[0].Schema.OpenAPIV3Schema)
 	documentLoader := gojsonschema.NewGoLoader(d)
 
 	result, err := gojsonschema.Validate(loader, documentLoader)

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: k8s-rds

--- a/deploy/operator-cluster-role.yaml
+++ b/deploy/operator-cluster-role.yaml
@@ -10,7 +10,7 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - k8s.io
+  - tradeshift.com
   resources:
   - databases
   verbs:


### PR DESCRIPTION
This commit upgrades Database CRD API version to v1 which is a must in order to be able to upgrade EKS to 1.22.
Current databases won't be changed.