### PR TITLE
POPS-2560 Add status field to CRD validation schema

### DIFF
--- a/crd/crd.go
+++ b/crd/crd.go
@@ -155,6 +155,20 @@ func NewDatabaseCRD() *apiextv1.CustomResourceDefinition {
 										},
 									},
 								},
+								"status": {
+									Type:        "object",
+									Description: "This field is added by k8s-rds operator in order to have the status of the underlying database.",
+									Properties: map[string]apiextv1.JSONSchemaProps{
+										"message": {
+											Type:        "string",
+											Description: "Provides details about creation of underlying database.",
+										},
+										"state": {
+											Type:        "string",
+											Description: "The state of the underlying database like Created/Failed.",
+										},
+									},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
This commit extends CRD validation schema with status field
which is added by k8s-rds operator in order to get the
status of underlying database.