### PR TITLE
POPS-2603 Make k8s-rds multi-arch compatible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,19 +6,9 @@ on:
 
   workflow_dispatch:
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Docker Push
-        uses: tradeshift/actions-docker@v1
-        with:
-          password: ${{ secrets.GCLOUD_SERVICE_ACCOUNT_KEY_NOBASE64 }}
-          repository: eu.gcr.io/tradeshift-base/k8s-rds
-          platform: linux/amd64
-          useqemu: true
+  docker-multi-arch:
+    uses: tradeshift/actions-workflow-multiarch/.github/workflows/docker-multiarch.yml@master
+    with:
+      registry: eu.gcr.io/tradeshift-base/k8s-rds
+    secrets:
+      eu-key: ${{ secrets.GCLOUD_SERVICE_ACCOUNT_KEY_NOBASE64 }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,22 +5,10 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
-      - name: Docker Build
-        uses: tradeshift/actions-docker@v1
-        with:
-          password: ${{ secrets.GCLOUD_SERVICE_ACCOUNT_KEY_NOBASE64 }}
-          repository: eu.gcr.io/tradeshift-base/k8s-rds
-          platform: linux/amd64
-          useqemu: true
-          tags: |
-            eu.gcr.io/tradeshift-base/k8s-rds:pr
+  docker-multi-arch:
+    uses: tradeshift/actions-workflow-multiarch/.github/workflows/docker-multiarch.yml@master
+    with:
+      registry: eu.gcr.io/tradeshift-base/k8s-rds
+      tags: pr
+    secrets:
+      eu-key: ${{ secrets.GCLOUD_SERVICE_ACCOUNT_KEY_NOBASE64 }}


### PR DESCRIPTION
This creates multi-arch compatible images so the service can run on both x86 and arm64 nodes.